### PR TITLE
adding data loaders for nyt, socc, ynacc

### DIFF
--- a/hackashop_datasets/nyt.py
+++ b/hackashop_datasets/nyt.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import glob
+from pathlib import Path
+
+
+def nyt_load(path):
+    '''
+    From a path, reads all csv files 
+    with comments as pandas dataframe.
+    '''
+    data_dir = Path(path)
+    appended_ds = []
+    for f in glob.glob(data_dir + 'Comments*.csv'):
+        d = pd.read_csv(f)
+        appended_ds.append(d)
+    data = pd.concat(appended_ds)
+    return data

--- a/hackashop_datasets/socc.py
+++ b/hackashop_datasets/socc.py
@@ -1,0 +1,42 @@
+import pandas as pd
+from pathlib import Path
+
+from project_settings import SOCC_DATASET
+
+def socc_load(path, file='SFU_constructiveness_toxicity_corpus.csv'):
+    '''
+    Read single annotated file as pandas dataframe.
+    '''
+    data_dir = Path(path)
+    data_file = data_dir / file
+    data = pd.read_csv(data_file)
+    return data
+
+socc_toxic_labels = {True:1, False:0}
+
+def load_socc_data(label_map, file='SFU_constructiveness_toxicity_corpus.csv',
+                    label='toxic'):
+    '''
+    Load and prepare training data.
+    :param label_map: defines the classfication problem: relevant string labels -> integer labels;
+    returns: texts, labels
+    '''
+    data = socc_load(SOCC_DATASET, file)
+    text_column = data['comment_text']
+    
+    # create custom toxic label
+    if label == 'toxic':
+        toxic_level = data.toxicity_level.apply(lambda x: '3' in x or '4' in x)
+        not_constructive = data.is_constructive == 'no'
+        label_column = toxic_level & not_constructive
+
+    else:
+        label_column = data[label]
+    texts, labels = [], []
+    for i in data.index:
+        label = label_column[i]
+        if label in label_map: # ignore labels such as NaN
+            text = text_column[i]
+            texts.append(text)
+            labels.append(label_map[label])
+    return texts, labels

--- a/hackashop_datasets/ynacc.py
+++ b/hackashop_datasets/ynacc.py
@@ -15,6 +15,7 @@ def ynacc_load(path, file="ydata-ynacc-v1_0_expert_annotations.tsv"):
 
 
 ynacc_constructive_labels = {'Not constructive':0, 'Constructive':1}
+# ynacc_toxic_labels = {True:1, False:0}
 
 def load_ynacc_data(label_map, file="ydata-ynacc-v1_0_expert_annotations.tsv",
                     label='constructiveclass'):
@@ -25,7 +26,17 @@ def load_ynacc_data(label_map, file="ydata-ynacc-v1_0_expert_annotations.tsv",
     '''
     data = ynacc_load(YNACC_DATASET, file)
     text_column = data['text']
-    label_column = data[label]
+    
+    # create custom toxic label
+    if label == 'toxic':
+        
+        insulting = data.sd_type.fillna('').apply(lambda x: 'insulting' in x)
+        mean = data.tone.fillna('').apply(lambda x: 'mean' in x.lower())
+        constructive = data.constructiveclass == 'Constructive'
+        label_column = (insulting | mean) & (~constructive)
+
+    else:
+        label_column = data[label]
     # print all labels
     # print(set([label_column[i] for i in data.index]))
     # label map, and filter -> label not recognized, example discarded


### PR DESCRIPTION
Added data loaders for the socc and nyt data set. The nyt data set does not have any blocked or toxic comments so probably won't use for classification but could use for fine tuning language model. Made some edits to ynacc adding the custom toxic label.
Will work on the data unification part next, maybe make some changes and just create a class for all the data loaders.